### PR TITLE
Fixed login bug for users without authmap mapping.

### DIFF
--- a/brukar_client/brukar_client.oauth.php
+++ b/brukar_client/brukar_client.oauth.php
@@ -100,7 +100,7 @@ function brukar_client_login($data) {
   }
 
   $authmap_user = db_query('SELECT uid FROM {authmap} WHERE module = :module AND authname = :ident', array(':ident' => $data['id'], ':module' => 'brukar'))->fetch();
-  if ($user === FALSE) {
+  if ($authmap_user === FALSE) {
     $provided = module_invoke_all('brukar_client_user', $edit);
     $user = !empty($provided) ? $provided[0] : user_save(NULL, $edit);
     user_set_authmaps($user, array('authname_brukar' => $data['id']));


### PR DESCRIPTION
Residual bug from #1.

Integrity check was done against the global user, which at this point always will be the 'anonymous user', instead of the returned authmap record.
